### PR TITLE
importing missing class namespace

### DIFF
--- a/routes/web.php
+++ b/routes/web.php
@@ -1,6 +1,7 @@
 <?php
 
 use App\Http\Controllers\UserController;
+use App\Http\Controllers\AdminController;
 use Illuminate\Support\Facades\Route;
 
 Route::get('/', function () {


### PR DESCRIPTION
Causa:
   Ao direcionar para a tela de login de admin, um erro aparece na tela informando que a classe AdminController não existe.

Solução:
   Foi verificado que está faltando a importação do namespace na página de routers.php, após a importação ser adicionada, a tela voltou a aparecer.